### PR TITLE
cli: implement du command

### DIFF
--- a/client/operations/get_workflow_disk_usage_parameters.go
+++ b/client/operations/get_workflow_disk_usage_parameters.go
@@ -69,7 +69,7 @@ type GetWorkflowDiskUsageParams struct {
 
 	   Optional. Additional input parameters and operational options.
 	*/
-	Parameters interface{}
+	Parameters GetWorkflowDiskUsageBody
 
 	/* WorkflowIDOrName.
 
@@ -142,13 +142,13 @@ func (o *GetWorkflowDiskUsageParams) SetAccessToken(accessToken *string) {
 }
 
 // WithParameters adds the parameters to the get workflow disk usage params
-func (o *GetWorkflowDiskUsageParams) WithParameters(parameters interface{}) *GetWorkflowDiskUsageParams {
+func (o *GetWorkflowDiskUsageParams) WithParameters(parameters GetWorkflowDiskUsageBody) *GetWorkflowDiskUsageParams {
 	o.SetParameters(parameters)
 	return o
 }
 
 // SetParameters adds the parameters to the get workflow disk usage params
-func (o *GetWorkflowDiskUsageParams) SetParameters(parameters interface{}) {
+func (o *GetWorkflowDiskUsageParams) SetParameters(parameters GetWorkflowDiskUsageBody) {
 	o.Parameters = parameters
 }
 
@@ -187,10 +187,8 @@ func (o *GetWorkflowDiskUsageParams) WriteToRequest(r runtime.ClientRequest, reg
 			}
 		}
 	}
-	if o.Parameters != nil {
-		if err := r.SetBodyParam(o.Parameters); err != nil {
-			return err
-		}
+	if err := r.SetBodyParam(o.Parameters); err != nil {
+		return err
 	}
 
 	// path param workflow_id_or_name

--- a/client/operations/get_workflow_disk_usage_responses.go
+++ b/client/operations/get_workflow_disk_usage_responses.go
@@ -176,6 +176,46 @@ func (o *GetWorkflowDiskUsageInternalServerError) readResponse(response runtime.
 	return nil
 }
 
+/*GetWorkflowDiskUsageBody get workflow disk usage body
+swagger:model GetWorkflowDiskUsageBody
+*/
+type GetWorkflowDiskUsageBody struct {
+
+	// search
+	Search string `json:"search,omitempty"`
+
+	// summarize
+	Summarize bool `json:"summarize,omitempty"`
+}
+
+// Validate validates this get workflow disk usage body
+func (o *GetWorkflowDiskUsageBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get workflow disk usage body based on context it is used
+func (o *GetWorkflowDiskUsageBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowDiskUsageBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowDiskUsageBody) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowDiskUsageBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
 /*GetWorkflowDiskUsageOKBody get workflow disk usage o k body
 swagger:model GetWorkflowDiskUsageOKBody
 */

--- a/client/operations/get_workflows_parameters.go
+++ b/client/operations/get_workflows_parameters.go
@@ -72,12 +72,6 @@ type GetWorkflowsParams struct {
 	*/
 	IncludeProgress *bool
 
-	/* IncludeRetentionRules.
-
-	   Include workspace retention rules of the workflows.
-	*/
-	IncludeRetentionRules *bool
-
 	/* IncludeWorkspaceSize.
 
 	   Include size information of the workspace.
@@ -205,17 +199,6 @@ func (o *GetWorkflowsParams) WithIncludeProgress(includeProgress *bool) *GetWork
 // SetIncludeProgress adds the includeProgress to the get workflows params
 func (o *GetWorkflowsParams) SetIncludeProgress(includeProgress *bool) {
 	o.IncludeProgress = includeProgress
-}
-
-// WithIncludeRetentionRules adds the includeRetentionRules to the get workflows params
-func (o *GetWorkflowsParams) WithIncludeRetentionRules(includeRetentionRules *bool) *GetWorkflowsParams {
-	o.SetIncludeRetentionRules(includeRetentionRules)
-	return o
-}
-
-// SetIncludeRetentionRules adds the includeRetentionRules to the get workflows params
-func (o *GetWorkflowsParams) SetIncludeRetentionRules(includeRetentionRules *bool) {
-	o.IncludeRetentionRules = includeRetentionRules
 }
 
 // WithIncludeWorkspaceSize adds the includeWorkspaceSize to the get workflows params
@@ -354,23 +337,6 @@ func (o *GetWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		if qIncludeProgress != "" {
 
 			if err := r.SetQueryParam("include_progress", qIncludeProgress); err != nil {
-				return err
-			}
-		}
-	}
-
-	if o.IncludeRetentionRules != nil {
-
-		// query param include_retention_rules
-		var qrIncludeRetentionRules bool
-
-		if o.IncludeRetentionRules != nil {
-			qrIncludeRetentionRules = *o.IncludeRetentionRules
-		}
-		qIncludeRetentionRules := swag.FormatBool(qrIncludeRetentionRules)
-		if qIncludeRetentionRules != "" {
-
-			if err := r.SetQueryParam("include_retention_rules", qIncludeRetentionRules); err != nil {
 				return err
 			}
 		}

--- a/cmd/du.go
+++ b/cmd/du.go
@@ -1,0 +1,131 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"reanahub/reana-client-go/client"
+	"reanahub/reana-client-go/client/operations"
+	"reanahub/reana-client-go/utils"
+	"reanahub/reana-client-go/validation"
+
+	"github.com/spf13/cobra"
+)
+
+const duDesc = `
+Get workspace disk usage.
+
+The ` + "``du``" + ` command allows to chech the disk usage of given workspace.
+
+Examples:
+
+  $ reana-client du -w myanalysis.42 -s
+
+  $ reana-client du -w myanalysis.42 -s --human-readable
+
+  $ reana-client du -w myanalysis.42 --filter name=data/
+`
+
+const duFilterFlagDesc = `Filter results to show only files that match certain filtering
+criteria such as file name or size.
+Use --filter <columm_name>=<column_value> pairs.
+Available filters are 'name' and 'size'.`
+
+func newDuCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "du",
+		Short: "Get workspace disk usage.",
+		Long:  duDesc,
+		Run: func(cmd *cobra.Command, args []string) {
+			token, _ := cmd.Flags().GetString("access-token")
+			if token == "" {
+				token = os.Getenv("REANA_ACCESS_TOKEN")
+			}
+			serverURL := os.Getenv("REANA_SERVER_URL")
+			workflow, _ := cmd.Flags().GetString("workflow")
+			if workflow == "" {
+				workflow = os.Getenv("REANA_WORKON")
+			}
+
+			validation.ValidateAccessToken(token)
+			validation.ValidateServerURL(serverURL)
+			validation.ValidateWorkflow(workflow)
+			du(cmd)
+		},
+	}
+
+	cmd.Flags().StringP("access-token", "t", "", "Access token of the current user.")
+	cmd.Flags().
+		StringP("workflow", "w", "", "Name or UUID of the workflow. Overrides value of REANA_WORKON environment variable.")
+	cmd.Flags().BoolP("summarize", "s", false, "Display total.")
+	cmd.Flags().BoolP("human-readable", "r", false, "Show disk size in human readable format.")
+	cmd.Flags().StringArray("filter", []string{}, duFilterFlagDesc)
+
+	return cmd
+}
+
+func du(cmd *cobra.Command) {
+	token, _ := cmd.Flags().GetString("access-token")
+	if token == "" {
+		token = os.Getenv("REANA_ACCESS_TOKEN")
+	}
+	summarize, _ := cmd.Flags().GetBool("summarize")
+	humanReadable, _ := cmd.Flags().GetBool("human-readable")
+	workflow, _ := cmd.Flags().GetString("workflow")
+	if workflow == "" {
+		workflow = os.Getenv("REANA_WORKON")
+	}
+	filter, _ := cmd.Flags().GetStringArray("filter")
+
+	filterNames := []string{"size", "name"}
+	_, searchFilter := utils.ParseListFilters(filter, filterNames)
+
+	duParams := operations.NewGetWorkflowDiskUsageParams()
+	duParams.SetAccessToken(&token)
+	duParams.SetWorkflowIDOrName(workflow)
+	additionalParams := operations.GetWorkflowDiskUsageBody{
+		Summarize: summarize,
+		Search:    searchFilter,
+	}
+	duParams.SetParameters(additionalParams)
+
+	duResp, err := client.ApiClient().Operations.GetWorkflowDiskUsage(duParams)
+	if err != nil {
+		fmt.Println("Error: Disk usage could not be retrieved:")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	displayDuPayload(duResp.Payload, humanReadable)
+}
+
+func displayDuPayload(p *operations.GetWorkflowDiskUsageOKBody, humanReadable bool) {
+	if len(p.DiskUsageInfo) == 0 {
+		fmt.Println("Error: No files matching filter criteria.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("%-12s %-30s\n", "SIZE", "NAME")
+
+	for _, diskUsageInfo := range p.DiskUsageInfo {
+		if utils.HasAnyPrefix(diskUsageInfo.Name, utils.FilesBlacklist) {
+			continue
+		}
+
+		var sizeInfo string
+		if humanReadable {
+			sizeInfo = diskUsageInfo.Size.HumanReadable
+		} else {
+			sizeInfo = fmt.Sprintf("%g", diskUsageInfo.Size.Raw)
+		}
+
+		fmt.Printf("%-12s .%-30s\n", sizeInfo, diskUsageInfo.Name)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newPingCmd())
 	cmd.AddCommand(newInfoCmd())
 	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newDuCmd())
 
 	return cmd
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,9 +16,27 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/spf13/cobra"
 )
+
+// Available run statuses
+var runStatuses = []string{
+	"created",
+	"running",
+	"finished",
+	"failed",
+	"deleted",
+	"stopped",
+	"queued",
+	"pending",
+}
+
+// Files black list
+var FilesBlacklist = []string{".git/", "/.git/"}
 
 func ExecuteCommand(root *cobra.Command, args ...string) (output string, err error) {
 	buf := new(bytes.Buffer)
@@ -67,4 +85,57 @@ func NewRequest(token string, serverURL string, endpoint string) []byte {
 	}
 
 	return respBytes
+}
+
+func ParseListFilters(filter []string, filterNames []string) ([]string, string) {
+	searchFilters := make(map[string][]string)
+	var statusFilters []string
+
+	for _, value := range filter {
+		if !strings.Contains(value, "=") {
+			fmt.Println("Error: Wrong input format. Please use --filter filter_name=filter_value")
+			os.Exit(1)
+		}
+
+		filterNameAndValue := strings.SplitN(value, "=", 2)
+		filterName := strings.ToLower(filterNameAndValue[0])
+		filterValue := filterNameAndValue[1]
+
+		if !slices.Contains(filterNames, filterName) {
+			fmt.Printf("Error: Filter %s is not valid", filterName)
+			os.Exit(1)
+		}
+
+		if filterName == "status" && !slices.Contains(runStatuses, filterValue) {
+			fmt.Printf("Error: Input status value %s is not valid. ", filterValue)
+			os.Exit(1)
+		}
+
+		if filterName == "status" {
+			statusFilters = append(statusFilters, filterValue)
+		} else {
+			searchFilters[filterName] = append(searchFilters[filterName], filterValue)
+		}
+	}
+
+	searchFiltersString := ""
+	if len(searchFilters) > 0 {
+		searchFiltersByteArray, err := json.Marshal(searchFilters)
+		if err != nil {
+			fmt.Println("Error: ", err)
+			os.Exit(1)
+		}
+		searchFiltersString = string(searchFiltersByteArray)
+	}
+
+	return statusFilters, searchFiltersString
+}
+
+func HasAnyPrefix(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/validation/utils.go
+++ b/validation/utils.go
@@ -29,3 +29,12 @@ func ValidateServerURL(serverURL string) {
 		os.Exit(1)
 	}
 }
+
+func ValidateWorkflow(workflow string) {
+	if strings.TrimSpace(workflow) == "" {
+		fmt.Println(
+			"Error: Workflow name must be provided either with `--workflow` option or with REANA_WORKON environment variable",
+		)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
closes #18

After considering some package options (including go-pretty, tablewriter, table and tabwriter), I reached the conclusion that `go-pretty` would be better, for the following reasons:
- Many users (only falling behind tablewriter)
- Simple way to create and customize tables
- Provides some predefined styles
- Also provides ways to customize lists, progress bars and text, which could prove useful later
- Active developers (unlike tablewriter, whose last update was more than a year ago)

Right now, the tables follow a very simplistic style:
![image](https://user-images.githubusercontent.com/55768934/178500243-0086278b-1732-4286-8efe-2ade2e5e69fc.png)

However, there are also coloured and more complex styles like this one:
![image](https://user-images.githubusercontent.com/55768934/178500493-87073368-b2dd-43eb-9e23-7e5b3a3e1b48.png)

Which kind of style do you think we should choose here?